### PR TITLE
Make TreemapChartMeasurer composition local

### DIFF
--- a/treemap-compose-android/src/androidTest/java/by/overpass/treemapchart/android/TreemapChartTest.kt
+++ b/treemap-compose-android/src/androidTest/java/by/overpass/treemapchart/android/TreemapChartTest.kt
@@ -1,7 +1,7 @@
 package by.overpass.treemapchart.android
 
 import androidx.compose.material.MaterialTheme
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
@@ -30,12 +30,13 @@ class TreemapChartTest {
     private fun testTreemapDisplayed(measurer: TreemapChartMeasurer) {
         composeTestRule.setContent {
             MaterialTheme {
-                TreemapChart(
-                    data = sampleTreeData,
-                    evaluateItem = Int::toDouble,
-                    treemapChartMeasurer = remember { measurer }
-                ) { it ->
-                    SimpleTreemapItem(it)
+                CompositionLocalProvider(LocalTreemapChartMeasurer provides measurer) {
+                    TreemapChart(
+                        data = sampleTreeData,
+                        evaluateItem = Int::toDouble,
+                    ) { it ->
+                        SimpleTreemapItem(it)
+                    }
                 }
             }
         }

--- a/treemap-compose-android/src/main/java/by/overpass/treemapchart/android/LocalTreemapChartMeasurer.kt
+++ b/treemap-compose-android/src/main/java/by/overpass/treemapchart/android/LocalTreemapChartMeasurer.kt
@@ -1,0 +1,7 @@
+package by.overpass.treemapchart.android
+
+import androidx.compose.runtime.compositionLocalOf
+import by.overpass.treemapchart.core.measure.TreemapChartMeasurer
+import by.overpass.treemapchart.core.measure.squarified.SquarifiedMeasurer
+
+val LocalTreemapChartMeasurer = compositionLocalOf<TreemapChartMeasurer> { SquarifiedMeasurer() }

--- a/treemap-example/src/main/java/by/overpass/treemapchart/example/ComplexChart.kt
+++ b/treemap-example/src/main/java/by/overpass/treemapchart/example/ComplexChart.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import by.overpass.treemapchart.android.TreemapChart
-import by.overpass.treemapchart.core.measure.squarified.SquarifiedMeasurer
 import by.overpass.treemapchart.core.tree.Tree
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -172,7 +171,6 @@ internal fun ComplexChart(modifier: Modifier = Modifier, onBack: () -> Unit) {
         TreemapChart(
             data = tree!!,
             evaluateItem = { it.value.toDouble() },
-            treemapChartMeasurer = SquarifiedMeasurer(),
             modifier = modifier,
         ) { node, GroupContent ->
             if (node.children.isEmpty()) {
@@ -201,9 +199,12 @@ private fun CategoryItem(item: CategoryItem, modifier: Modifier = Modifier) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.SpaceAround,
-        modifier = modifier.border(1.dp, Color.White)
+        modifier = modifier
+            .border(1.dp, Color.White)
             .clickable {
-                Toast.makeText(context, "${item.name} clicked", Toast.LENGTH_SHORT).show()
+                Toast
+                    .makeText(context, "${item.name} clicked", Toast.LENGTH_SHORT)
+                    .show()
             }
             .padding(4.dp),
     ) {

--- a/treemap-example/src/main/java/by/overpass/treemapchart/example/EasyChart.kt
+++ b/treemap-example/src/main/java/by/overpass/treemapchart/example/EasyChart.kt
@@ -7,13 +7,11 @@ import androidx.compose.material.Button
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import by.overpass.treemapchart.android.TreemapChart
-import by.overpass.treemapchart.core.measure.squarified.SquarifiedMeasurer
 import by.overpass.treemapchart.core.tree.tree
 
 private val simpleTreeData = tree(10) {
@@ -43,7 +41,6 @@ internal fun EasyChart(
         TreemapChart(
             data = simpleTreeData,
             evaluateItem = Int::toDouble,
-            treemapChartMeasurer = remember { SquarifiedMeasurer() },
             modifier = Modifier
                 .weight(1f),
         ) { item ->


### PR DESCRIPTION
Closes #67

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for customizing the treemap chart measuring strategy by introducing a `LocalTreemapChartMeasurer` composition local, which allows users to provide their own implementation of the `TreemapChartMeasurer` interface. It also removes the `treemapChartMeasurer` parameter from the `TreemapChart` and `TreemapChartNode` functions.

### Changes
- Added `LocalTreemapChartMeasurer` composition local
- Introduced `TreemapChartMeasurer` interface
- Removed `treemapChartMeasurer` parameter from `TreemapChart` and `TreemapChartNode` functions
- Updated usage of `TreemapChart` and `TreemapChartNode` functions in related files

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->