### PR TITLE
Remove macrobenchmark from UI-test workflow

### DIFF
--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -21,8 +21,8 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '17'
-      - name: UI tests + Macrobenchmark
+      - name: UI tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 29
-          script: ./gradlew :treemap-chart-compose:connectedCheck :sample:android:macrobenchmark:connectedBenchmarkAndroidTest
+          script: ./gradlew :treemap-chart-compose:connectedCheck


### PR DESCRIPTION
Closes #102 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the UI test workflow to run UI tests only without the macrobenchmark tests.

### Detailed summary
- Updated the workflow to run UI tests only without macrobenchmark tests.
- Changed the script to run UI tests for the `treemap-chart-compose` module.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->