### PR TITLE
Handle jvm source and target compatibility in each module

### DIFF
--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     alias(libs.plugins.android.test)
     alias(libs.plugins.kotlin.android)
@@ -50,5 +53,11 @@ dependencies {
 androidComponents {
     beforeVariants(selector().all()) {
         it.enable = it.buildType == "benchmark"
+    }
+}
+
+tasks.withType<KotlinCompile> {
+    compilerOptions {
+        jvmTarget = JvmTarget.fromTarget(properties["jvm.version"].toString())
     }
 }

--- a/sample/android/build.gradle.kts
+++ b/sample/android/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     alias(libs.plugins.android.app)
     alias(libs.plugins.kotlin.android)
@@ -37,12 +40,6 @@ android {
             matchingFallbacks += listOf("release")
             isDebuggable = false
         }
-        //        create("benchmark") {
-//            initWith(release)
-//            signingConfig = signingConfigs.getByName("debug")
-//            matchingFallbacks.add("release")
-//            proguardFiles("benchmark-rules.pro")
-//        }
     }
     compileOptions {
         sourceCompatibility = JavaVersion.toVersion(properties["jvm.version"].toString())
@@ -61,4 +58,10 @@ dependencies {
     implementation(libs.androidx.profile.installer)
     debugImplementation(libs.compose.runtime.tracing)
     detektPlugins(libs.compose.detekt.rules)
+}
+
+tasks.withType<KotlinCompile> {
+    compilerOptions {
+        jvmTarget = JvmTarget.fromTarget(properties["jvm.version"].toString())
+    }
 }

--- a/sample/desktop/build.gradle.kts
+++ b/sample/desktop/build.gradle.kts
@@ -1,4 +1,6 @@
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
@@ -34,4 +36,15 @@ compose.desktop {
 
 dependencies {
     detektPlugins(libs.compose.detekt.rules)
+}
+
+java {
+    sourceCompatibility = JavaVersion.toVersion(properties["jvm.version"].toString())
+    targetCompatibility = JavaVersion.toVersion(properties["jvm.version"].toString())
+}
+
+tasks.withType<KotlinCompile> {
+    compilerOptions {
+        jvmTarget = JvmTarget.fromTarget(properties["jvm.version"].toString())
+    }
 }


### PR DESCRIPTION
Closes #125 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing Kotlin compilation settings across various Gradle build files by specifying `jvmTarget` and Java compatibility based on project properties, while also removing commented-out code related to a benchmark configuration.

### Detailed summary
- Added `JvmTarget` import and configuration for `KotlinCompile` tasks in `benchmark/build.gradle.kts`.
- Introduced Java source and target compatibility settings in `sample/desktop/build.gradle.kts`.
- Implemented `KotlinCompile` task configuration in `sample/android/build.gradle.kts`.
- Removed commented-out benchmark configuration in `sample/android/build.gradle.kts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->